### PR TITLE
Portal image: domain-agnostic Keycloak URL + arm64-buildable backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,7 +21,7 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /
 
 # Add Docker official software source (use VERSION_CODENAME from /etc/os-release)
 RUN . /etc/os-release && echo \
-  "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian ${VERSION_CODENAME} stable" \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian ${VERSION_CODENAME} stable" \
   > /etc/apt/sources.list.d/docker.list
 
 # Install docker CLI + compose plugin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,10 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
       args:
-        - VITE_KEYCLOAK_URL=${PORTAL_KEYCLOAK_BASE_URL}
+        # Relative URL: keycloak-js resolves it against the current origin, so the
+        # built image is domain-agnostic (works behind any host at /auth) instead
+        # of baking one deployment's absolute Keycloak URL at build time.
+        - VITE_KEYCLOAK_URL=/auth
         - VITE_KEYCLOAK_REALM=${KEYCLOAK_REALM:-digitaltwins}
         - VITE_KEYCLOAK_CLIENT_ID=portal-frontend
     container_name: ${PROJECT_NAME}-portal-frontend


### PR DESCRIPTION
## What

Two build fixes that make the portal image reusable across deployments and buildable on arm64:

1. **Frontend** — change the build arg `VITE_KEYCLOAK_URL` from the deployment's absolute `${PORTAL_KEYCLOAK_BASE_URL}` to the relative `/auth`.
2. **Backend** — change the Docker apt source in `backend/Dockerfile` from a hardcoded `arch=amd64` to `arch=$(dpkg --print-architecture)`.

## Why

**1. Domain-agnostic frontend image.** `keycloak-js` receives `VITE_KEYCLOAK_URL` at build time (`frontend/src/bootstrap/keycloak.ts` → `import.meta.env.VITE_KEYCLOAK_URL`), so building with an absolute URL bakes one deployment's Keycloak host into the image. Using a relative `/auth` lets keycloak-js resolve it against the current origin, so the same built image works behind any host (each resolves to its own `/auth`, which the platform gateway routes to Keycloak). This makes the frozen/prebuilt portal image reusable across deployments (e.g. abi1, abi2) instead of being pinned to the domain it was built for.

**2. arm64-buildable backend image.** The backend Dockerfile's `docker.list` apt source pinned `arch=amd64`. Building the backend on arm64 (e.g. an Apple-Silicon dev laptop) then tried to install `docker-ce-cli:amd64`, whose `libc6:amd64` dependency is unsatisfiable → "unable to correct problems / broken packages" and the build fails. `$(dpkg --print-architecture)` makes the repo match the build platform — `amd64` on servers, `arm64` on Apple Silicon. (`dpkg` runs inside the Debian build container, not on the host.)

## Change

- `docker-compose.yml` — `VITE_KEYCLOAK_URL` build arg → `/auth` (+ explanatory comment).
- `backend/Dockerfile` — apt-source arch → `$(dpkg --print-architecture)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
